### PR TITLE
Update deployment for OIDC

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,26 +9,45 @@ on:
       - published
 
 jobs:
-  pypi_push:
-    environment: deploy
-    if: "github.repository == 'MDAnalysis/mda-xdrlib'"
-    name: Build, upload and test pure Python wheels
+  test_pypi_push:
+    environment:
+      name: deploy
+      url: https://test.pypi.org/p/mda-xdrlib
+    permissions:
+      id-token: write
+    if: |
+      "github.repository == 'MDAnalysis/mda-xdrlib'" &&
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+    name: Build, upload and test pure Python wheels to TestPypi
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: testpypi_deploy
         uses: MDAnalysis/pypi-deployment@main
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         with:
-          token: ${{ secrets.TEST_PYPI_API_TOKEN }}
           test_submission: true
           package_name: 'mda_xdrlib'
+
+  pypi_push:
+    environment:
+      name: deploy
+      url: https://pypi.org/p/mda-xdrlib
+    permissions:
+      id-token: write
+    if: |
+      "github.repository == 'MDAnalysis/mda-xdrlib'" &&
+      (github.event_name == 'release' && github.event.action == 'published')
+    name: Build, upload and test pure Python wheels to PyPi
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
 
       - name: pypi_deploy
         uses: MDAnalysis/pypi-deployment@main
         if: github.event_name == 'release' && github.event.action == 'published'
         with:
-          token: ${{ secrets.PYPI_API_TOKEN }}
           package_name: 'mda_xdrlib'


### PR DESCRIPTION
Bloats the deployment yaml a bit, but at least now we don't need API tokens.